### PR TITLE
Add terraform

### DIFF
--- a/terraform/init_template.tpl
+++ b/terraform/init_template.tpl
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+
+mkdir -p /mnt/efs
+yum -y -q install git amazon-efs-utils
+echo "${efs_name}:/ /mnt/efs nfs defaults,_netdev 0 0" >> /tmp/debug_efs.txt
+mount -t nfs4 "${efs_name}:/" /mnt/efs
+echo "${efs_name}:/ /mnt/efs nfs defaults,_netdev 0 0" >> /etc/fstab
+
+cd /home/centos
+sudo -u centos git clone https://github.com/asascience/Cloud-Sandbox.git
+cd Cloud-Sandbox/cloudflow/workflows/scripts
+sudo -u centos ./nosofs-setup-instance.sh > /tmp/setup 2>&1

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -1,0 +1,216 @@
+terraform {
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 3.27"
+    }
+  }
+}
+
+provider "aws" {
+  region  = var.preferred_region
+}
+
+resource "aws_vpc" "cloud_vpc" {
+   cidr_block = "10.0.0.0/16"
+   tags = {
+      Name = "IOOS Cloud Sandbox VPC Terraform"
+      Project = var.project_name
+    }
+}
+
+resource "aws_subnet" "main" {
+  vpc_id   = aws_vpc.cloud_vpc.id
+  cidr_block = "10.0.0.0/24"
+  availability_zone = var.availability_zone
+   tags = {
+      Name = "IOOS Cloud Sandbox VPC Subnet Terraform"
+      Project = var.project_name
+    }
+}
+
+resource "aws_internet_gateway" "gw" {
+  vpc_id = aws_vpc.cloud_vpc.id
+   tags = {
+      Name = "IOOS Cloud Sandbox VPC Subnet Internet Gateway"
+      Project = var.project_name
+    }
+}
+
+resource "aws_route_table" "default" {
+    vpc_id = aws_vpc.cloud_vpc.id
+
+    route {
+      cidr_block = "0.0.0.0/0"
+      gateway_id = aws_internet_gateway.gw.id
+    }
+
+   tags = {
+      Name = "IOOS Cloud Sandbox VPC Subnet Internet Gateway"
+      Project = var.project_name
+    }
+}
+
+resource "aws_route_table_association" "main" {
+  subnet_id = aws_subnet.main.id
+  route_table_id = aws_route_table.default.id
+}
+
+# base sg
+resource "aws_security_group" "base_sg" {
+   vpc_id = aws_vpc.cloud_vpc.id
+   tags = {
+      Name = "IOOS Cloud Sandbox Base SG"
+      Project = var.project_name
+    }
+}
+
+resource "aws_security_group" "efs_ingress" {
+   vpc_id = aws_vpc.cloud_vpc.id
+   ingress {
+     security_groups = [aws_security_group.base_sg.id]
+     from_port = 2049
+     to_port = 2049
+     protocol = "tcp"
+   }
+   tags = {
+      Name = "IOOS Cloud Sandbox Base SG"
+      Project = var.project_name
+   }
+
+   # allow all outgoing from NFS
+   egress {
+      security_groups = [aws_security_group.base_sg.id]
+      from_port = 0
+      to_port = 0
+      protocol = "all"
+   }
+}
+
+
+# TODO: fix these so that the managed policies attach properly
+#resource "aws_iam_role" "sandbox_iam_role" {
+#  name = "ioos_cloud_sandbox_terraform_role"
+#  assume_role_policy = <<EOF
+#{
+#  "Version": "2012-10-17",
+#  "Statement": [
+#    {
+#      "Action": "sts:AssumeRole",
+#      "Principal": {
+#        "Service": "ec2.amazonaws.com"
+#      },
+#      "Effect": "Allow",
+#      "Sid": ""
+#    }
+#  ]
+#}
+#EOF
+#  tags = {
+#    Name = var.instance_name
+#    Project = var.project_name
+#  }
+#}
+#
+#resource "aws_iam_role_policy_attachment" "sandbox_role_policy_attach" {
+#   count = length(var.managed_policies)
+#   policy_arn = element(var.managed_policies, count.index)
+#   role = aws_iam_role.sandbox_iam_role.name
+#}
+#
+#resource "aws_iam_instance_profile" "cloud_sandbox_iam_instance_profile" {
+#    name = "ioos_cloud_sandbox_terraform_role"
+#    role = aws_iam_role.sandbox_iam_role.name
+#}
+
+resource "aws_security_group" "ssh_ingress" {
+  vpc_id = aws_vpc.cloud_vpc.id
+  ingress {
+          description = "Allow SSH from approved IP addresses"
+          from_port = 22
+          to_port   = 22
+          protocol = "tcp"
+          cidr_blocks = [var.ssh_cidr]
+         }
+}
+
+resource "aws_key_pair" "default" {
+   key_name = "main_key"
+   public_key = var.public_key
+}
+
+# uncomment to make CentOS 7 HVM AMI available for use.  Will need to also
+# be reflected in the instance's AMI id
+data "aws_ami" "centos_7_latest" {
+  owners = ["679593333241"]
+  most_recent = true
+
+  filter {
+    name = "name"
+    values = ["CentOS Linux 7 x86_64 HVM EBS ENA*"]
+  }
+
+  filter {
+    name   = "root-device-type"
+    values = ["ebs"]
+  }
+
+  filter {
+    name   = "virtualization-type"
+    values = ["hvm"]
+  }
+}
+
+resource "aws_instance" "model_head_node" {
+  # Base CentOS 7 AMI
+  ami = data.aws_ami.centos_7_latest.id
+  # AMI for NOSOFS Setup
+  #ami           = "ami-0c5fc45da5f63247b"
+  # c5n.18xlarge is required for EFA support
+  instance_type = "c5n.18xlarge"
+  # TODO: uncomment once IAM fixed
+  #iam_instance_profile = aws_iam_instance_profile.cloud_sandbox_iam_instance_profile.name
+  # TODO: Terraform does not yet support enabling EFA.  Find some other means
+  #       of doing so.
+  associate_public_ip_address = true
+  root_block_device {
+        delete_on_termination = true
+        volume_size = 12
+      }
+  cpu_threads_per_core = 1
+  depends_on = [aws_internet_gateway.gw]
+  key_name = "main_key"
+  subnet_id = aws_subnet.main.id
+  vpc_security_group_ids = [
+    aws_security_group.base_sg.id,
+    aws_security_group.ssh_ingress.id,
+    aws_security_group.efs_ingress.id
+  ]
+  tags = {
+    Name = var.instance_name
+    Project = var.project_name
+  }
+}
+
+
+resource "aws_placement_group" "cloud_sandbox_placement_group" {
+  name = "IOOS Cloud Sandbox Terraform Placement Group"
+  strategy = "cluster"
+  tags = {
+    project = var.project_name
+  }
+}
+
+resource "aws_efs_file_system" "main_efs" {
+  encrypted = false
+  availability_zone_name = var.availability_zone
+  tags = {
+     Name = "Cloud sandbox Terraform EFS"
+     Project = var.project_name
+  }
+}
+
+resource "aws_efs_mount_target" "mount_target_main_efs" {
+    subnet_id = aws_subnet.main.id
+    file_system_id = aws_efs_file_system.main_efs.id
+}

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -89,39 +89,39 @@ resource "aws_security_group" "efs_ingress" {
 
 
 # TODO: fix these so that the managed policies attach properly
-#resource "aws_iam_role" "sandbox_iam_role" {
-#  name = "ioos_cloud_sandbox_terraform_role"
-#  assume_role_policy = <<EOF
-#{
-#  "Version": "2012-10-17",
-#  "Statement": [
-#    {
-#      "Action": "sts:AssumeRole",
-#      "Principal": {
-#        "Service": "ec2.amazonaws.com"
-#      },
-#      "Effect": "Allow",
-#      "Sid": ""
-#    }
-#  ]
-#}
-#EOF
-#  tags = {
-#    Name = var.instance_name
-#    Project = var.project_name
-#  }
-#}
-#
-#resource "aws_iam_role_policy_attachment" "sandbox_role_policy_attach" {
-#   count = length(var.managed_policies)
-#   policy_arn = element(var.managed_policies, count.index)
-#   role = aws_iam_role.sandbox_iam_role.name
-#}
-#
-#resource "aws_iam_instance_profile" "cloud_sandbox_iam_instance_profile" {
-#    name = "ioos_cloud_sandbox_terraform_role"
-#    role = aws_iam_role.sandbox_iam_role.name
-#}
+resource "aws_iam_role" "sandbox_iam_role" {
+  name = "ioos_cloud_sandbox_terraform_role"
+  assume_role_policy = <<EOF
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Action": "sts:AssumeRole",
+      "Principal": {
+        "Service": "ec2.amazonaws.com"
+      },
+      "Effect": "Allow",
+      "Sid": ""
+    }
+  ]
+}
+EOF
+  tags = {
+    Name = var.instance_name
+    Project = var.project_name
+  }
+}
+
+resource "aws_iam_role_policy_attachment" "sandbox_role_policy_attach" {
+   count = length(var.managed_policies)
+   policy_arn = element(var.managed_policies, count.index)
+   role = aws_iam_role.sandbox_iam_role.name
+}
+
+resource "aws_iam_instance_profile" "cloud_sandbox_iam_instance_profile" {
+    name = "ioos_cloud_sandbox_terraform_role"
+    role = aws_iam_role.sandbox_iam_role.name
+}
 
 resource "aws_security_group" "ssh_ingress" {
   vpc_id = aws_vpc.cloud_vpc.id
@@ -168,8 +168,7 @@ resource "aws_instance" "model_head_node" {
   #ami           = "ami-0c5fc45da5f63247b"
   # c5n.18xlarge is required for EFA support
   instance_type = "c5n.18xlarge"
-  # TODO: uncomment once IAM fixed
-  #iam_instance_profile = aws_iam_instance_profile.cloud_sandbox_iam_instance_profile.name
+  iam_instance_profile = aws_iam_instance_profile.cloud_sandbox_iam_instance_profile.name
   # TODO: Terraform does not yet support enabling EFA.  Find some other means
   #       of doing so.
   associate_public_ip_address = true

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -176,6 +176,10 @@ resource "aws_instance" "model_head_node" {
         delete_on_termination = true
         volume_size = 12
       }
+
+  # Seems to require both cpu_core_count = 36 and
+  # cpu_threads_per_core = 1 in order to have 36 vCPUs without hyperthreading
+  cpu_core_count = 36
   cpu_threads_per_core = 1
   depends_on = [aws_internet_gateway.gw]
   key_name = "main_key"

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -89,7 +89,6 @@ resource "aws_security_group" "efs_sg" {
 }
 
 
-# TODO: fix these so that the managed policies attach properly
 resource "aws_iam_role" "sandbox_iam_role" {
   name = "ioos_cloud_sandbox_terraform_role"
   assume_role_policy = <<EOF
@@ -140,8 +139,6 @@ resource "aws_key_pair" "default" {
    public_key = var.public_key
 }
 
-# uncomment to make CentOS 7 HVM AMI available for use.  Will need to also
-# be reflected in the instance's AMI id
 data "aws_ami" "centos_7_latest" {
   owners = ["679593333241"]
   most_recent = true

--- a/terraform/outputs.tf
+++ b/terraform/outputs.tf
@@ -1,0 +1,4 @@
+output "instance_public_ip" {
+   description = "Public IP Address of the EC2 Instance"
+   value = aws_instance.model_head_node.public_ip
+}

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -1,0 +1,34 @@
+variable "preferred_region" {
+  description = "Preferred region in which to launch EC2 instances. Defaults to us-east-1"
+  type        = string
+  default     = "us-east-1"
+}
+variable "instance_name" {
+  description = "Value of the Name tag for the EC2 instance"
+  type        = string
+  default     = "IOOS Cloud Sandbox Terraform Test Instance - Head Node"
+}
+variable "project_name" {
+  description = "Value of the Name tag for the EC2 instance"
+  type        = string
+  default     = "IOOS Cloud Sandbox"
+}
+variable "availability_zone" {
+  description = "Availability zone to use"
+  type        = string
+  default     = "us-east-1a"
+}
+variable "ssh_cidr" {
+  description = "CIDR for the accepted SSH string"
+  type = string
+}
+variable "public_key" {
+  description = "Contents of the SSH public key to be used for authentication"
+  type = string
+}
+
+variable "managed_policies" {
+  default = ["arn:aws:iam::aws:policy/AmazonEC2FullAccess",
+             "arn:aws:iam::aws:policy/aws-service-role/AmazonFSxServiceRolePolicy",
+             "arn:aws:iam::aws:policy/AmazonS3FullAccess"]
+}

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -29,6 +29,6 @@ variable "public_key" {
 
 variable "managed_policies" {
   default = ["arn:aws:iam::aws:policy/AmazonEC2FullAccess",
-             "arn:aws:iam::aws:policy/aws-service-role/AmazonFSxServiceRolePolicy",
-             "arn:aws:iam::aws:policy/AmazonS3FullAccess"]
+             "arn:aws:iam::aws:policy/AmazonS3FullAccess",
+             "arn:aws:iam::aws:policy/AmazonFSxFullAccess"]
 }


### PR DESCRIPTION
Adds Terraform configuration for setting up AWS resources for IOOS Cloud Sandbox.

Current known issues:

- The userdata init scripts continue after booting the machine and do not finish installing the sandbox requirements for some time after boot.
- Enabling EFA does not appear to be currently supported in Terraform, although there does seem to be at least one PR open for this issue: https://github.com/hashicorp/terraform-provider-aws/pull/18841