### PR TITLE
JupyterHub installation updates

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,7 +28,7 @@ terraform/SAVE.mysettings.tfvars
 *.pem
 *.key
 */.secret
-**/*nda*
+*/*nda*
 dev.tfvars
 my.tfvars
 my.plan

--- a/.gitignore
+++ b/.gitignore
@@ -28,7 +28,7 @@ terraform/SAVE.mysettings.tfvars
 *.pem
 *.key
 */.secret
-*/*nda*
+**/*nda*
 dev.tfvars
 my.tfvars
 my.plan

--- a/cloudflow/workflows/scripts/install_conda_jupyterhub.sh
+++ b/cloudflow/workflows/scripts/install_conda_jupyterhub.sh
@@ -20,7 +20,7 @@
 
   # install JupyterHub under conda environment (https://jupyterhub.readthedocs.io/en/stable/quickstart.html)
   conda activate base
-  conda install -c conda-forge jupyterhub  # installs jupyterhub and proxy
+  conda install -c conda-forge jupyterhub oauthenticator  # installs jupyterhub and proxy
   conda install jupyterlab notebook  # needed if running the notebook servers in the same environment
 
   # good instruction source: https://medium.com/swlh/how-to-install-jupyterhub-using-conda-without-runing-as-root-and-make-it-a-service-59b843fead12
@@ -37,6 +37,16 @@
 
   ## TODO: Think about changing config
   sudo cp system/jupyterhub_config.py /opt/jupyterhub/jupyterhub_config.py
+
+  # create the systemd service
+  sudo setenforce 0 # may or may not be needed, disables SELinux to prevent issues with these steps
+  sudo mkdir /etc/jupyterhub/service
+  sudo cp system/jupyterhub.service /etc/jupyterhub/service/jupyterhub.service
+  sudo chown -R jupyter /etc/jupyter/service
+  sudo ln -s /etc/jupyterhub/service/jupyterhub.service /etc/systemd/system/jupyterhub.service
+  sudo systemctl daemon-reload
+  sudo systemctl enable jupyterhub
+  sudo systemctl start jupyterhub
 
   ### ------------------------ OLD CODE ------------------------------------------------------ ##
 
@@ -75,7 +85,7 @@
   sudo cp system/jupyterhub_config.py /opt/jupyterhub/jupyterhub_config.py
 
   # create systemd service
-  sudo useradd --system --shell "/sbin/nologin" --home-dir "/etc/jupyter" --comment "JupytherHub system user" jupyter
+  sudo useradd --system --shell "/sbin/nologin" --home-dir "/etc/jupyter" --comment "JupyterHub system user" jupyter
   sudo chown jupyter:jupyter /opt/jupyterhub
 
   sudo mkdir -p /opt/jupyterhub/etc/systemd

--- a/cloudflow/workflows/scripts/install_conda_jupyterhub.sh
+++ b/cloudflow/workflows/scripts/install_conda_jupyterhub.sh
@@ -21,7 +21,8 @@
   # install JupyterHub under conda environment (https://jupyterhub.readthedocs.io/en/stable/quickstart.html)
   conda activate base
   conda install -yc conda-forge jupyterhub oauthenticator sudospawner # installs jupyterhub and proxy
-  conda install -y jupyterlab notebook  # needed if running the notebook servers in the same environment
+  # needed if running the notebook servers in the same environment; nb_conda_kernels makes other environments visible
+  conda install -y jupyterlab notebook nb_conda_kernels
 
   # create system account that will run jupyterhub
   sudo useradd jupyter

--- a/cloudflow/workflows/scripts/install_conda_jupyterhub.sh
+++ b/cloudflow/workflows/scripts/install_conda_jupyterhub.sh
@@ -1,14 +1,6 @@
 #!/bin/env bash
 
-  # install JupyterHub (https://github.com/jupyterhub/jupyterhub-the-hard-way/blob/HEAD/docs/installation-guide-hard.md)
-
-  # install npm 
-  #curl -fsSL https://rpm.nodesource.com/setup_16.x | sudo bash -
-  #sudo yum clean all && sudo yum makecache fast
-  #sudo yum install -y gcc-c++ make
-  #sudo yum install -y nodejs
-
-    # install conda
+  # install conda
   rm /tmp/Miniconda3-py310_23.1.0-1-Linux-x86_64.sh
   curl "Miniconda3-py310_23.1.0-1-Linux-x86_64.sh" -o /tmp/Miniconda3-py310_23.1.0-1-Linux-x86_64.sh
   sudo bash /tmp/Miniconda3-py310_23.1.0-1-Linux-x86_64.sh -b -p /opt/conda
@@ -20,22 +12,19 @@
 
   # install JupyterHub under conda environment (https://jupyterhub.readthedocs.io/en/stable/quickstart.html)
   conda activate base
-  conda install -c conda-forge jupyterhub oauthenticator  # installs jupyterhub and proxy
-  conda install jupyterlab notebook  # needed if running the notebook servers in the same environment
+  conda install -yc conda-forge jupyterhub oauthenticator sudospawner # installs jupyterhub and proxy
+  conda install -y jupyterlab notebook  # needed if running the notebook servers in the same environment
 
-  # good instruction source: https://medium.com/swlh/how-to-install-jupyterhub-using-conda-without-runing-as-root-and-make-it-a-service-59b843fead12
-  conda install -c conda-forge sudospawner # use sudospawner to elevate permissions
-
+  # create system account that will run jupyterhub
   sudo useradd jupyter
   sudo groupadd jupyterhub
   sudo usermod jupyter -G jupyterhub
 
   sudo cp system/jupytersudoers /etc/sudoers.d/jupytersudoers
 
+  # copy over configs
   sudo mkdir /etc/jupyterhub
   sudo chown jupyter /etc/jupyterhub
-
-  ## TODO: Think about changing config
   sudo cp system/jupyterhub_config.py /opt/jupyterhub/jupyterhub_config.py
 
   # create the systemd service

--- a/cloudflow/workflows/scripts/install_conda_jupyterhub.sh
+++ b/cloudflow/workflows/scripts/install_conda_jupyterhub.sh
@@ -3,10 +3,44 @@
   # install JupyterHub (https://github.com/jupyterhub/jupyterhub-the-hard-way/blob/HEAD/docs/installation-guide-hard.md)
 
   # install npm 
-  curl -fsSL https://rpm.nodesource.com/setup_16.x | sudo bash -
-  sudo yum clean all && sudo yum makecache fast
-  sudo yum install -y gcc-c++ make
-  sudo yum install -y nodejs
+  #curl -fsSL https://rpm.nodesource.com/setup_16.x | sudo bash -
+  #sudo yum clean all && sudo yum makecache fast
+  #sudo yum install -y gcc-c++ make
+  #sudo yum install -y nodejs
+
+    # install conda
+  rm /tmp/Miniconda3-py310_23.1.0-1-Linux-x86_64.sh
+  curl "Miniconda3-py310_23.1.0-1-Linux-x86_64.sh" -o /tmp/Miniconda3-py310_23.1.0-1-Linux-x86_64.sh
+  sudo bash /tmp/Miniconda3-py310_23.1.0-1-Linux-x86_64.sh -b -p /opt/conda
+  sudo ln -sf /opt/conda/etc/profile.d/conda.sh /etc/profile.d/conda.sh
+
+  # allows all users to make changes to conda environments (alternatively could give permissions to each user)
+  sudo chmod -R a+rwX /opt/conda/envs
+  sudo chown -R ec2-user/ec2-user /opt/conda # allow user to install here; one should not use 'sudo conda' commands
+
+  # install JupyterHub under conda environment (https://jupyterhub.readthedocs.io/en/stable/quickstart.html)
+  conda activate base
+  conda install -c conda-forge jupyterhub  # installs jupyterhub and proxy
+  conda install jupyterlab notebook  # needed if running the notebook servers in the same environment
+
+  # good instruction source: https://medium.com/swlh/how-to-install-jupyterhub-using-conda-without-runing-as-root-and-make-it-a-service-59b843fead12
+  conda install -c conda-forge sudospawner # use sudospawner to elevate permissions
+
+  sudo useradd jupyter
+  sudo groupadd jupyterhub
+  sudo usermod jupyter -G jupyterhub
+
+  sudo cp system/jupytersudoers /etc/sudoers.d/jupytersudoers
+
+  sudo mkdir /etc/jupyterhub
+  sudo chown jupyter /etc/jupyterhub
+
+  ## TODO: Think about changing config
+  sudo cp system/jupyterhub_config.py /opt/jupyterhub/jupyterhub_config.py
+
+  ### ------------------------ OLD CODE ------------------------------------------------------ ##
+
+  # make kernel visible to JupyterHub
 
   # install nginx
   sudo yum install -y nginx
@@ -52,16 +86,7 @@
   sudo systemctl enable jupyterhub
   sudo systemctl start jupyterhub
 
-  # install conda
-  rm /tmp/Anaconda3-2022.05-Linux-x86_64.sh
-  curl "https://repo.anaconda.com/archive/Anaconda3-2022.05-Linux-x86_64.sh" -o /tmp/Anaconda3-2022.05-Linux-x86_64.sh
-  sudo bash /tmp/Anaconda3-2022.05-Linux-x86_64.sh -b -p /opt/conda
-  sudo ln -sf /opt/conda/etc/profile.d/conda.sh /etc/profile.d/conda.sh
 
-  # allows all users to make changes to conda environments (alternatively could give permissions to each user)
-  sudo chmod -R a+rwX /opt/conda/envs
-
-  # make kernel visible to JupyterHub
   sudo /opt/conda/bin/conda create --prefix /opt/conda/envs/pangeo xarray zarr dask ipykernel --yes
   sudo /opt/jupyterhub/bin/jupyter kernelspec install /opt/conda/envs/python
 

--- a/cloudflow/workflows/scripts/install_conda_jupyterhub.sh
+++ b/cloudflow/workflows/scripts/install_conda_jupyterhub.sh
@@ -1,5 +1,13 @@
 #!/bin/env bash
 
+  # install nginx
+  sudo yum install -y nginx
+  sudo cp system/jupyterhub.conf /etc/nginx/conf.d/jupyterhub.conf
+  #TODO: Copy certs to correct place
+  # /etc/ssl/star_rpsgroup_com.crt
+  sudo systemctl enable nginx
+  sudo systemctl start nginx
+
   # install conda
   rm /tmp/Miniconda3-py310_23.1.0-1-Linux-x86_64.sh
   curl "Miniconda3-py310_23.1.0-1-Linux-x86_64.sh" -o /tmp/Miniconda3-py310_23.1.0-1-Linux-x86_64.sh
@@ -36,76 +44,3 @@
   sudo systemctl daemon-reload
   sudo systemctl enable jupyterhub
   sudo systemctl start jupyterhub
-
-  ### ------------------------ OLD CODE ------------------------------------------------------ ##
-
-  # make kernel visible to JupyterHub
-
-  # install nginx
-  sudo yum install -y nginx
-  sudo cp system/jupyterhub.conf /etc/nginx/conf.d/jupyterhub.conf
-  #TODO: Copy certs to correct place
-  # /etc/ssl/star_rpsgroup_com.crt
-  sudo systemctl enable nginx
-  sudo systemctl start nginx
-
-  # create virtual python environment
-  sudo python3 -m venv /opt/jupyterhub/
-  sudo /opt/jupyterhub/bin/python -m pip install --upgrade pip
-  sudo /opt/jupyterhub/bin/python -m pip install wheel
-  sudo /opt/jupyterhub/bin/python -m pip install setuptools_rust
-  sudo /opt/jupyterhub/bin/python3 -m pip install ipywidgets
-  sudo /opt/jupyterhub/bin/python -m pip install jupyterhub jupyterlab
-  # allow interaction with conda-store (https://pypi.org/project/nb-conda-store-kernels/)
-  #sudo /opt/jupyterhub/bin/python -m pip install nb_conda_store_kernels
-  #sudo /opt/jupyterhub/bin/python -m nb_conda_store_kernels.install --enable
-
-  # needed if running the notebook servers in the same environment
-  sudo /opt/jupyterhub/bin/python -m pip install notebook
-  sudo /opt/jupyterhub/bin/python -m pip install oauthenticator
-
-  sudo -E env "PATH=$PATH" npm install -g configurable-http-proxy
-
-  # start the proxy - this is done automatically by jupyterhub
-  # configurable-http-proxy --default-target=http://localhost:8888
-
-  # Copy config over
-  # sudo curl "https://ioos-cloud-sandbox.s3.amazonaws.com/public/jupyterhub/jupyterhub_config.py" -o /opt/jupyterhub/jupyterhub_config.py
-  sudo cp system/jupyterhub_config.py /opt/jupyterhub/jupyterhub_config.py
-
-  # create systemd service
-  sudo useradd --system --shell "/sbin/nologin" --home-dir "/etc/jupyter" --comment "JupyterHub system user" jupyter
-  sudo chown jupyter:jupyter /opt/jupyterhub
-
-  sudo mkdir -p /opt/jupyterhub/etc/systemd
-  #sudo curl "https://ioos-cloud-sandbox.s3.amazonaws.com/public/jupyterhub/jupyterhub.service" -o /opt/jupyterhub/etc/systemd/jupyterhub.service
-  sudo cp system/jupyterhub.service /opt/jupyterhub/etc/systemd/jupyterhub.service
-  sudo ln -s /opt/jupyterhub/etc/systemd/jupyterhub.service /usr/lib/systemd/system/jupyterhub.service
-  sudo systemctl daemon-reload
-  sudo systemctl enable jupyterhub
-  sudo systemctl start jupyterhub
-
-
-  sudo /opt/conda/bin/conda create --prefix /opt/conda/envs/pangeo xarray zarr dask ipykernel --yes
-  sudo /opt/jupyterhub/bin/jupyter kernelspec install /opt/conda/envs/python
-
-  # To activate this environment, use
-  #     $ conda activate /opt/conda/envs/python
-  #
-  # To deactivate an active environment, use
-  #     $ conda deactivate
-
-  # setup Python environment for users
-  # Setting up users' own conda environments
-  # On login they should run conda init or /opt/conda/bin/conda. 
-  # They can then use conda to set up their environment, although they must also install ipykernel. 
-  # Once done, they can enable their kernel using:
-
-  # /path/to/kernel/env/bin/python -m ipykernel install --user --name 'python-my-env' --display-name "Python My Env"
-  sudo /opt/conda/envs/python/bin/python -m ipykernel install --prefix=/opt/jupyterhub/ --name 'python' --display-name "Python (default)"
-
-  sudo /opt/conda/envs/python/bin/python -m ipykernel install --user --name 'python' --display-name "Python (default spec)"
-
-  # ************** Work in progress ******************
-  # TODO: configure sudospawner so we can run jupyterhub as jupyter user
-  # sudo /opt/jupyterhub/bin/python -m pip install sudospawner

--- a/cloudflow/workflows/scripts/install_jupyterhub.sh
+++ b/cloudflow/workflows/scripts/install_jupyterhub.sh
@@ -11,6 +11,8 @@
   # install nginx
   sudo yum install -y nginx
   sudo cp system/jupyterhub.conf /etc/nginx/conf.d/jupyterhub.conf
+  #TODO: Copy certs to correct place
+  # /etc/ssl/star_rpsgroup_com.crt
   sudo systemctl enable nginx
   sudo systemctl start nginx
 
@@ -21,6 +23,9 @@
   sudo /opt/jupyterhub/bin/python -m pip install setuptools_rust
   sudo /opt/jupyterhub/bin/python3 -m pip install ipywidgets
   sudo /opt/jupyterhub/bin/python -m pip install jupyterhub jupyterlab
+  # allow interaction with conda-store (https://pypi.org/project/nb-conda-store-kernels/)
+  sudo /opt/jupyterhub/bin/python -m pip install nb_conda_store_kernels
+  sudo /opt/jupyterhub/bin/python -m nb_conda_store_kernels.install --enable
 
   # needed if running the notebook servers in the same environment
   sudo /opt/jupyterhub/bin/python -m pip install notebook
@@ -53,7 +58,14 @@
   sudo bash /tmp/Anaconda3-2022.05-Linux-x86_64.sh -b -p /opt/conda
   sudo ln -sf /opt/conda/etc/profile.d/conda.sh /etc/profile.d/conda.sh
 
+  # allows all users to make changes to conda environments (alternatively could give permissions to each user)
+  sudo chmod -R a+rwX /opt/conda/envs
+
+  # make kernel visible to JupyterHub
   sudo /opt/conda/bin/conda create --prefix /opt/conda/envs/python ipykernel --yes
+
+  # install conda-store-server
+  conda install -c conda-forge conda-store-server
 
   # To activate this environment, use
   #     $ conda activate /opt/conda/envs/python
@@ -73,5 +85,3 @@
   # ************** Work in progress ******************
   # TODO: configure sudospawner so we can run jupyterhub as jupyter user
   # sudo /opt/jupyterhub/bin/python -m pip install sudospawner
-
-

--- a/cloudflow/workflows/scripts/system/jupyterhub.conf
+++ b/cloudflow/workflows/scripts/system/jupyterhub.conf
@@ -6,16 +6,16 @@ map $http_upgrade $connection_upgrade {
 server {
 
     listen       80;
-    server_name jupyterhub.rpsgroup.com;
-    return 301 https://jupyterhub.rpsgroup.com$request_uri;
+    server_name sandbox-dev.ioos.us;
+    return 301 https://sandbox-dev.ioos.us$request_uri;
 }
 
 server {
 
     listen   443 ssl;
-    ssl_certificate        /etc/ssl/star_rpsgroup_com.crt;
-    ssl_certificate_key    /etc/ssl/star_rpsgroup_com.key;
-    server_name  jupyterhub.rpsgroup.com;
+    ssl_certificate        /etc/ssl/star_ioos_us.crt;
+    ssl_certificate_key    /etc/ssl/star_ioos_us.key;
+    server_name  sandbox-dev.ioos.us;
 
     location / {
 

--- a/cloudflow/workflows/scripts/system/jupyterhub.service
+++ b/cloudflow/workflows/scripts/system/jupyterhub.service
@@ -3,11 +3,13 @@ Description=JupyterHub
 After=syslog.target network.target
 
 [Service]
-#User=jupyter
-User=root
-Environment="PATH=/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/opt/jupyterhub/bin"
-ExecStart=/opt/jupyterhub/bin/jupyterhub -f /opt/jupyterhub/jupyterhub_config.py
-PIDFile=/opt/jupyterhub/jupyterhub.pid
+Type=simple
+User=jupyter
+ExecStart=/etc/jupyterhub/runJupyterhub.sh
+WorkingDirectory=/etc/jupyterhub
+Restart=on-failure
+RestartSec=1min
+TimeoutSec=5min
 
 [Install]
 WantedBy=multi-user.target

--- a/cloudflow/workflows/scripts/system/jupyterhub_config.py
+++ b/cloudflow/workflows/scripts/system/jupyterhub_config.py
@@ -25,7 +25,7 @@ c.GoogleOAuthenticator.client_id = ''
 c.GoogleOAuthenticator.client_secret = ''
 c.LocalAuthenticator.create_system_users = True
 c.Authenticator.delete_invalid_users = False
-c.Authenticator.admin_users = {'jonmjoyce@gmail.com', 'patrick.tripp.rps@gmail.com'}
+c.Authenticator.admin_users = {'jupyter', 'jonmjoyce', 'patrick.tripp.rps'}
 c.Authenticator.username_map = { "jonmjoyce@gmail.com": "jonmjoyce", "patrick.tripp.rps@gmail.com": "patrick.tripp" }
 
 ## Fill this out to make users administrators
@@ -217,7 +217,7 @@ c.JupyterHub.bind_url = 'http://:8000'
 #c.JupyterHub.cookie_secret = traitlets.Undefined
 
 ## File in which to store the cookie secret.
-c.JupyterHub.cookie_secret_file = '/opt/jupyterhub/jupyterhub_cookie_secret'
+#c.JupyterHub.cookie_secret_file = '/opt/jupyterhub/jupyterhub_cookie_secret'
 
 ## The location of jupyterhub data files (e.g. /usr/local/share/jupyterhub)
 #c.JupyterHub.data_files_path = '/home/centos/.local/share/jupyterhub'
@@ -227,7 +227,7 @@ c.JupyterHub.cookie_secret_file = '/opt/jupyterhub/jupyterhub_cookie_secret'
 #c.JupyterHub.db_kwargs = {}
 
 ## url for the database. e.g. `sqlite:///jupyterhub.sqlite`
-c.JupyterHub.db_url = 'sqlite:///opt/jupyterhub/jupyterhub.sqlite'
+#c.JupyterHub.db_url = 'sqlite:///opt/jupyterhub/jupyterhub.sqlite'
 
 ## log all database transactions. This has A LOT of output
 #c.JupyterHub.debug_db = False
@@ -513,8 +513,8 @@ c.JupyterHub.db_url = 'sqlite:///opt/jupyterhub/jupyterhub.sqlite'
 #c.JupyterHub.oauth_token_expires_in = 0
 
 ## File to write PID Useful for daemonizing JupyterHub.
-c.JupyterHub.pid_file = '/opt/jupyterhub/jupyterhub.pid'
-c.ConfigurableHTTPProxy.pid_file = '/opt/jupyterhub/jupyterhub-proxy.pid'
+#c.JupyterHub.pid_file = '/opt/jupyterhub/jupyterhub.pid'
+#c.ConfigurableHTTPProxy.pid_file = '/opt/jupyterhub/jupyterhub-proxy.pid'
 
 ## The public facing port of the proxy.
 #  
@@ -596,7 +596,7 @@ c.ConfigurableHTTPProxy.pid_file = '/opt/jupyterhub/jupyterhub-proxy.pid'
 #    - default: jupyterhub.spawner.LocalProcessSpawner
 #    - localprocess: jupyterhub.spawner.LocalProcessSpawner
 #    - simple: jupyterhub.spawner.SimpleLocalProcessSpawner
-#c.JupyterHub.spawner_class = 'jupyterhub.spawner.LocalProcessSpawner'
+c.JupyterHub.spawner_class = 'sudospawner.SudoSpawner'
 
 ## Path to SSL certificate file for the public facing interface of the proxy
 #  

--- a/cloudflow/workflows/scripts/system/jupytersudoers
+++ b/cloudflow/workflows/scripts/system/jupytersudoers
@@ -1,0 +1,11 @@
+# comma-separated whitelist of users that can spawn single-user servers
+# this should include all of your Hub users
+Runas_Alias JUPYTER_USERS = jupyter, jonmjoyce
+# the command(s) the Hub can run on behalf of the above users without needing a password
+# the exact path may differ, depending on how sudospawner was installed
+Cmnd_Alias JUPYTER_CMD = /opt/conda/bin/sudospawner
+# actually give the Hub user permission to run the above command on behalf
+# of the above users without prompting for a password
+#jupyter ALL=(JUPYTER_USERS) NOPASSWD:JUPYTER_CMD
+%jupyterhub ALL=(jupyter) /usr/bin/sudo
+jupyter ALL=(%jupyterhub) NOPASSWD:JUPYTER_CMD

--- a/cloudflow/workflows/scripts/system/runJupyterhub.sh
+++ b/cloudflow/workflows/scripts/system/runJupyterhub.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+# >>> conda initialize >>>
+# !! Contents within this block are managed by 'conda init' !!
+__conda_setup="$('/opt/conda/bin/conda' 'shell.bash' 'hook' 2> /dev/null)"
+if [ $? -eq 0 ]; then
+    eval "$__conda_setup"
+else
+    if [ -f "/opt/conda/etc/profile.d/conda.sh" ]; then
+        . "/opt/conda/etc/profile.d/conda.sh"
+    else
+        export PATH="/opt/conda/bin:$PATH"
+    fi
+fi
+unset __conda_setup
+# <<< conda initialize <<<
+conda activate base
+/opt/conda/bin/jupyterhub -f /etc/jupyterhub/jupyterhub_config.py 2>&1 | tee /home/jupyter/jupyterhub.log

--- a/jupyterhub/README.md
+++ b/jupyterhub/README.md
@@ -26,11 +26,11 @@ c.GoogleOAuthenticator.client_secret = "your_client_secret"
 
 ## Adding Users
 
-First, create the Linux user account if it doesn't already exist on the system.
+First, create the Linux user account if it doesn't already exist on the system, and add it to the jupyterhub group.
 
 ```
 sudo useradd example_user
-sudo usermod -aG wheel example_user
+sudo usermod -aG jupyterhub example_user
 ```
 
 Next, fill out the username mapping to map the Google user to a local Unix user. For example:

--- a/jupyterhub/README.md
+++ b/jupyterhub/README.md
@@ -73,6 +73,8 @@ Follow [these instructions](https://github.com/jupyterhub/jupyterhub-the-hard-wa
 
 If you are planning on running SSL/HTTPS, you will need to generate your own certificates and point the Nginx configuration to those.
 
+The Nginx configuration is located in `/etc/nginx/conf.d/`
+
 ## Debugging
 
 The JupyterHub logs are part of the `jupyterhub.service`. To inspect the logs:

--- a/jupyterhub/README.md
+++ b/jupyterhub/README.md
@@ -53,17 +53,18 @@ First, if you haven't already, set a password for the user account to login with
 ```
 sudo passwd example_user
 ```
-Then login as that user: `su example_user`
 
-Run `conda init`
-
-After creating the new Conda environment, run these commands to make it visible to the base kernel:
+Then login as that user, initialize Conda, and create a new environment.
 
 ```
-conda install ipykernel
-ipython kernel install --user --name=<any_name_for_kernel>
+su example_user
+conda init
+conda create -n environment_name ipykernel
 ```
 
+The package `nb_conda_kernels` is already installed and will make the environment visible as long as ipykernel is installed.
+
+The new kernel should now be listed in JupyterHub.
 
 ## Setting up SSL/HTTPS
 

--- a/jupyterhub/README.md
+++ b/jupyterhub/README.md
@@ -43,6 +43,20 @@ Optionally, you can assign administrators using the `c.Authenticator.admin_users
 c.Authenticator.admin_users = {'example_user@gmail.com'}
 ```
 
+## Setting up Conda environment
+
+Once the user account is created, that user will need to log in to the machine to set up their Conda environment.
+
+First, if you haven't already, set a password for the user account to login with:
+```
+sudo passwd example_user
+```
+Then login as that user: `su example_user`
+
+Run `conda init`
+
+
+
 ## Setting up SSL/HTTPS
 
 It is recommended to run Nginx as a reverse proxy to your JupyterHub instance. 
@@ -64,4 +78,3 @@ The JupyterHub service usually needs to be restarted for configuration changes t
 ```
 sudo systemctl restart jupyterhub.service
 ```
-

--- a/jupyterhub/README.md
+++ b/jupyterhub/README.md
@@ -1,13 +1,15 @@
 # JupyterHub Setup Instructions
 
-The Cloud Sandbox setup will automatically install the JupyterHub dependencies. However, additional configuration is required in order to enable user authentication.
+The Cloud Sandbox setup will automatically install the JupyterHub dependencies. However, additional configuration is required in order to enable user authentication. JupyterHub is installed in the `base` conda environment by default. 
 
-- JupyterHub install path: `/opt/jupyterhub`
-- JupyterHub config: `/opt/jupyterhub/jupyterhub_config.py`
+- Conda install: `/opt/conda`
+- JupyterHub config: `/etc/jupyterhub/jupyterhub_config.py`
+- JupyterHub run script: `/etc/jupyterhub/runJupyterhub.sh`
 - Nginx config: `/etc/nginx/conf.d/jupyterhub.conf`
 
 ## Helpful References
 
+- [How-to Install JupyterHub Using Conda Without Running as Root and Make It a Service](https://medium.com/swlh/how-to-install-jupyterhub-using-conda-without-runing-as-root-and-make-it-a-service-59b843fead12)
 - [JupyterHub The Hard Way](https://github.com/jupyterhub/jupyterhub-the-hard-way/blob/HEAD/docs/installation-guide-hard.md): Manual installation guide
 - [JupyterHub Deployment Course](https://professorkazarinoff.github.io/jupyterhub-engr114/google_oauth/)
 
@@ -15,7 +17,7 @@ The Cloud Sandbox setup will automatically install the JupyterHub dependencies. 
 
 See [these instructions](https://oauthenticator.readthedocs.io/en/latest/getting-started.html#google-setup) for configuring your Google credentials with OAuthenticator. You will [create a key on the Google platform](https://developers.google.com/identity/protocols/oauth2) and modify the JupyterHub config to have the public key.
 
-Once you've created the key, modify `/opt/jupyterhub/jupyterhub_config.py` values:
+Once you've created the key, modify `/etc/jupyterhub/jupyterhub_config.py` values:
 
 ```
 c.GoogleOAuthenticator.client_id = "your_client_id"
@@ -55,6 +57,12 @@ Then login as that user: `su example_user`
 
 Run `conda init`
 
+After creating the new Conda environment, run these commands to make it visible to the base kernel:
+
+```
+conda install ipykernel
+ipython kernel install --user --name=<any_name_for_kernel>
+```
 
 
 ## Setting up SSL/HTTPS


### PR DESCRIPTION
Updated the scripts and instructions to configure JupyterHub on a new machine. These commands were performed on Centos Stream 9. 

- Changed to install conda first, then run jupyterhub from conda
- Improved security by running JupyterHub on a system account (jupyter) instead of root
- Use sudospawner to improve security of users logging into system; prevents users from gaining root access
- Added instructions for creating new conda environments for users. Installed nb_conda_kernels to detect new kernels