### PR TITLE
Enable use of existing VPC and Subnet.   Parameterize Terraform S3 backend via config files. 

### DIFF
--- a/terraform/config.s3.tfbackend
+++ b/terraform/config.s3.tfbackend
@@ -1,0 +1,2 @@
+bucket = "cloud-sandbox-tfstate"
+region = "us-east-1"

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -58,6 +58,8 @@ resource "aws_placement_group" "cloud_sandbox_placement_group" {
 }
 
 resource "aws_vpc" "cloud_vpc" {
+   # we only will create this vpc if vpc_id is not passed in as a variable
+   count = var.vpc_id != null ? 0 : 1
    # This is a large vpc, 256 x 256 IPs available
    cidr_block = "10.0.0.0/16"
    enable_dns_support = true
@@ -68,20 +70,48 @@ resource "aws_vpc" "cloud_vpc" {
     }
 }
 
+
+data "aws_vpc" "pre-provisioned" {
+  # the pre-provisioned VPC will be returned if vpc_id matches an existing VPC
+  count = var.vpc_id != null ? 1 : 0
+  id = var.vpc_id
+}
+
 resource "aws_subnet" "main" {
-  vpc_id   = aws_vpc.cloud_vpc.id
-  # This subnet will allow 256 IPs
-  cidr_block = "10.0.0.0/24"
-  map_public_ip_on_launch = true
-  availability_zone = var.availability_zone
+   count = var.vpc_id != null ? 0 : 1
+   #vpc_id   = aws_vpc.cloud_vpc[0].id
+   vpc_id = local.vpc.id
+   # This subnet will allow 256 IPs
+   cidr_block = "10.0.0.0/24"
+   map_public_ip_on_launch = true
+   availability_zone = var.availability_zone
    tags = {
       Name = "${var.name_tag} Subnet"
       Project = var.project_tag
-    }
+   }
 }
 
+
+data "aws_subnet" "pre-provisioned" {
+  # the pre-provisioned Subnet will be returned if subnet_id matches an existing Subnet
+  count = var.subnet_id != null ? 1 : 0
+  id = var.subnet_id
+}
+
+
+# here we assign local variables for both the VPC and the Subnet we'll need to refer to to deploy further resources below:
+# use of the one() function is needed to ensure only a single value is assigned, rather than a tuple/set
+locals {
+  vpc = var.vpc_id != null ? one(data.aws_vpc.pre-provisioned[*]) : one(aws_vpc.cloud_vpc[*])
+  subnet = var.subnet_id != null ? one(data.aws_subnet.pre-provisioned[*]) : one(aws_subnet.main[*])
+
+}
+
+
 resource "aws_internet_gateway" "gw" {
-  vpc_id = aws_vpc.cloud_vpc.id
+   count = var.vpc_id != null ? 0 : 1
+   #vpc_id = aws_vpc.cloud_vpc[0].id
+   vpc_id = local.vpc.id
    tags = {
       Name = "${var.name_tag} Internet Gateway"
       Project = var.project_tag
@@ -89,22 +119,26 @@ resource "aws_internet_gateway" "gw" {
 }
 
 resource "aws_route_table" "default" {
-    vpc_id = aws_vpc.cloud_vpc.id
+   count = var.vpc_id != null ? 0 : 1
+   #vpc_id = aws_vpc.cloud_vpc[0].id
+   vpc_id = local.vpc.id
 
-    route {
-      cidr_block = "0.0.0.0/0"
-      gateway_id = aws_internet_gateway.gw.id
-    }
+   route {
+     cidr_block = "0.0.0.0/0"
+     gateway_id = one(aws_internet_gateway.gw[*].id)
+   }
    tags = {
-      Name = "${var.name_tag} Route Table"
-      Project = var.project_tag
-    }
+     Name = "${var.name_tag} Route Table"
+     Project = var.project_tag
+   }
 }
 
 resource "aws_route_table_association" "main" {
-  subnet_id = aws_subnet.main.id
-  route_table_id = aws_route_table.default.id
+  count = var.vpc_id != null ? 0 : 1
+  subnet_id = one(aws_subnet.main[*].id)
+  route_table_id = one(aws_route_table.default[*].id)
 }
+
 
 resource "aws_efs_file_system" "main_efs" {
   encrypted = false
@@ -116,7 +150,7 @@ resource "aws_efs_file_system" "main_efs" {
 }
 
 resource "aws_efs_mount_target" "mount_target_main_efs" {
-    subnet_id = aws_subnet.main.id
+    subnet_id = local.subnet.id
     security_groups = [aws_security_group.efs_sg.id]
     file_system_id = aws_efs_file_system.main_efs.id
 }
@@ -377,7 +411,8 @@ data "template_file" "init_instance" {
 # Can only attach efa adaptor to a stopped instance!
 resource "aws_network_interface" "standard" {
   
-  subnet_id   = aws_subnet.main.id
+  #subnet_id   = aws_subnet.main.id
+  subnet_id   = local.subnet.id
   description = "The network adaptor to attach to the instance if EFA is not supported"
   security_groups = [aws_security_group.base_sg.id,
                      aws_security_group.ssh_ingress.id,
@@ -390,8 +425,9 @@ resource "aws_network_interface" "standard" {
 
 # Can only attach efa adaptor to a stopped instance!
 resource "aws_network_interface" "efa_network_adapter" {
-
-  subnet_id   = aws_subnet.main.id
+  
+  #subnet_id   = aws_subnet.main.id
+  subnet_id   = local.subnet.id
   description = "The Elastic Fabric Adapter to attach to instance if supported"
   security_groups = [aws_security_group.base_sg.id,
                      aws_security_group.ssh_ingress.id,

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -6,9 +6,7 @@ terraform {
     }
   }
   backend "s3" {
-    bucket = "cloud-sandbox-tfstate"
     key    = "tfstate"
-    region = "us-east-2"
   }
 }
 
@@ -79,7 +77,6 @@ data "aws_vpc" "pre-provisioned" {
 
 resource "aws_subnet" "main" {
    count = var.vpc_id != null ? 0 : 1
-   #vpc_id   = aws_vpc.cloud_vpc[0].id
    vpc_id = local.vpc.id
    # This subnet will allow 256 IPs
    cidr_block = "10.0.0.0/24"
@@ -110,7 +107,6 @@ locals {
 
 resource "aws_internet_gateway" "gw" {
    count = var.vpc_id != null ? 0 : 1
-   #vpc_id = aws_vpc.cloud_vpc[0].id
    vpc_id = local.vpc.id
    tags = {
       Name = "${var.name_tag} Internet Gateway"
@@ -120,7 +116,6 @@ resource "aws_internet_gateway" "gw" {
 
 resource "aws_route_table" "default" {
    count = var.vpc_id != null ? 0 : 1
-   #vpc_id = aws_vpc.cloud_vpc[0].id
    vpc_id = local.vpc.id
 
    route {
@@ -411,7 +406,6 @@ data "template_file" "init_instance" {
 # Can only attach efa adaptor to a stopped instance!
 resource "aws_network_interface" "standard" {
   
-  #subnet_id   = aws_subnet.main.id
   subnet_id   = local.subnet.id
   description = "The network adaptor to attach to the instance if EFA is not supported"
   security_groups = [aws_security_group.base_sg.id,
@@ -426,7 +420,6 @@ resource "aws_network_interface" "standard" {
 # Can only attach efa adaptor to a stopped instance!
 resource "aws_network_interface" "efa_network_adapter" {
   
-  #subnet_id   = aws_subnet.main.id
   subnet_id   = local.subnet.id
   description = "The Elastic Fabric Adapter to attach to instance if supported"
   security_groups = [aws_security_group.base_sg.id,

--- a/terraform/mysettings.tfvars
+++ b/terraform/mysettings.tfvars
@@ -24,6 +24,18 @@ allowed_ssh_cidr = ""
 key_name = ""       # the filename of the private SSL key 
 public_key = ""     # the matching public key (ssh-keygen -y -f your-key-pair.pem) 
 
+
+# Example: 
+# vpc_id = "vpc-0381e9f82c9ae68e7"
+vpc_id = "" 		# the ID of an existing VPC to deploy resources to
+
+
+# Example: 
+# subnet_id = "subnet-01ce99f9006e8ed06"
+subnet_id = ""		# the ID of an existing Subnet within the VPC to deploy resources to
+
+
+
 #------------------------------------------------------------
 
 

--- a/terraform/outputs.tf
+++ b/terraform/outputs.tf
@@ -50,9 +50,14 @@ output "project_tag" {
     value = var.project_tag
 }
 
+output "aws_vpc" {
+    description = "AWS VPC"
+    value = local.vpc.id
+}
+
 output "aws_subnet" {
     description = "AWS Subnet"
-    value = aws_subnet.main.id
+    value = local.subnet.id
 }
 
 output "aws_placement_group" {

--- a/terraform/remote-state/main.tf
+++ b/terraform/remote-state/main.tf
@@ -1,9 +1,9 @@
 provider "aws" {
-  region = "us-east-2"
+  region  = var.preferred_region
 }
 
 resource "aws_s3_bucket" "terraform_state" {
-  bucket = "cloud-sandbox-tfstate"
+  bucket = var.tfstate_s3_bucket_name
      
   lifecycle {
     prevent_destroy = true

--- a/terraform/remote-state/s3.defaults.tfvars
+++ b/terraform/remote-state/s3.defaults.tfvars
@@ -1,0 +1,4 @@
+# The default values for S3 bucket creation that can be passed to terraform init via '-var-file=s3.defaults.tfvars' flag (or modified and then passed)
+
+tfstate_s3_bucket_name = "cloud-sandbox-tfstate"
+preferred_region = "us-east-1"

--- a/terraform/remote-state/variables.tf
+++ b/terraform/remote-state/variables.tf
@@ -1,0 +1,11 @@
+variable "preferred_region" {
+  description = "Region in which to create the S3 bucket for Terraform state backend storage."
+  type        = string
+  nullable     = false
+}
+
+variable "tfstate_s3_bucket_name" {
+  description = "Bucket name to use for Terraform state backend."
+  type        = string
+  nullable     = false
+}

--- a/terraform/security.tf
+++ b/terraform/security.tf
@@ -1,6 +1,7 @@
 # base sg
 resource "aws_security_group" "base_sg" {
-  vpc_id = aws_vpc.cloud_vpc.id
+  #vpc_id = aws_vpc.cloud_vpc.id
+  vpc_id = local.vpc.id
   ingress {
     self = true
     from_port = 0
@@ -20,7 +21,8 @@ resource "aws_security_group" "base_sg" {
 }
 
 resource "aws_security_group" "efs_sg" {
-   vpc_id = aws_vpc.cloud_vpc.id
+   #vpc_id = aws_vpc.cloud_vpc.id
+   vpc_id = local.vpc.id
    ingress {
      self = true
      from_port = 2049
@@ -42,7 +44,8 @@ resource "aws_security_group" "efs_sg" {
 }
 
 resource "aws_security_group" "ssh_ingress" {
-  vpc_id = aws_vpc.cloud_vpc.id
+  #vpc_id = aws_vpc.cloud_vpc.id
+  vpc_id = local.vpc.id
   ingress {
           description = "Allow SSH from approved IP addresses"
           from_port = 22

--- a/terraform/security.tf
+++ b/terraform/security.tf
@@ -1,6 +1,5 @@
 # base sg
 resource "aws_security_group" "base_sg" {
-  #vpc_id = aws_vpc.cloud_vpc.id
   vpc_id = local.vpc.id
   ingress {
     self = true
@@ -21,7 +20,6 @@ resource "aws_security_group" "base_sg" {
 }
 
 resource "aws_security_group" "efs_sg" {
-   #vpc_id = aws_vpc.cloud_vpc.id
    vpc_id = local.vpc.id
    ingress {
      self = true
@@ -44,7 +42,6 @@ resource "aws_security_group" "efs_sg" {
 }
 
 resource "aws_security_group" "ssh_ingress" {
-  #vpc_id = aws_vpc.cloud_vpc.id
   vpc_id = local.vpc.id
   ingress {
           description = "Allow SSH from approved IP addresses"

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -44,18 +44,52 @@ variable "use_efa" {
 variable "key_name" {
   description = "The name of the key-pair used to access the EC2 instances"
   type        = string
-  #default     = "terraform-key.pem"
+  nullable = false
 }
 
 variable "allowed_ssh_cidr" {
   description = "Public IP address/range allowed for SSH access"
   type = string
+  nullable = false
 }
 
 variable "public_key" {
   description = "Contents of the SSH public key to be used for authentication"
   type        = string
+  sensitive = true
+  nullable = false
+
+  validation {
+    condition     = length(var.public_key) > 8 && substr(var.public_key, 0, 8) == "ssh-rsa "
+    error_message = "The public_key value must start with \"ssh-rsa \"."
+  }
 }
+
+variable "vpc_id" {
+  description = "The ID of an existing VPC within the target region.  Specifying this value will skip creation of a new VPC."
+  type = string
+  default = null
+
+  validation {
+    condition     = var.vpc_id == null ? true : ( length(var.vpc_id) > 4 && substr(var.vpc_id, 0, 4) == "vpc-" )
+    error_message = "The vpc_id value must start with \"vpc-\"."
+  }
+
+}
+
+
+variable "subnet_id" {
+  description = "The ID of an existing Subnect within the target VPC.  Must be specified if using an exsiting VPC."
+  type = string
+  default = null
+
+  validation {
+    condition     = var.subnet_id == null ? true : ( length(var.subnet_id) > 7 && substr(var.subnet_id, 0, 7) == "subnet-" )
+    error_message = "The subnet_id value must start with \"subnet-\"."
+  }
+
+}
+
 
 variable "managed_policies" {
   description = "The attached IAM policies granting machine permissions"


### PR DESCRIPTION
This combines both some changes to the main Cloud Sandbox Terraform project to use an existing VPC/Subnet (via optional `vpc_id` and `subnet_id` parameters), and moves some of the S3 backend configurations to be stored in separate parameter files.

Adds an example file `config.s3.tfbackend` file that can be passed to `terraform init` per [Partial Configuration guidance](https://developer.hashicorp.com/terraform/language/settings/backends/configuration#partial-configuration), allowing greater deployment flexibility without modifying common project files.   

The S3 bucket creation config in the `remote-state` module is also moved to `preferred_region` and `tfstate_s3_bucket_name` variables, with an example config file `s3.defaults.tfvars` provided.

README instructions updated as well to reflect new usage/commands.