### PR TITLE
Allow creation of a new subnet within existing VPC

### DIFF
--- a/terraform/init_template.tpl
+++ b/terraform/init_template.tpl
@@ -42,10 +42,6 @@ cd /mnt/efs/fs1/save
 sudo -u $RUNUSER git clone https://github.com/ioos/Cloud-Sandbox.git
 cd Cloud-Sandbox/cloudflow/workflows/scripts
 
-BRANCH=master
-
-sudo -u $RUNUSER git checkout $BRANCH
-
 # Need to pass ami_name
 export ami_name=${ami_name}
 echo "ami name : $ami_name"

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -78,10 +78,15 @@ data "aws_vpc" "pre-provisioned" {
 resource "aws_subnet" "main" {
    count = var.subnet_id != null ? 0 : 1
    vpc_id = local.vpc.id
-   # This subnet will allow 256 IPs
-   cidr_block = "10.0.0.0/24"
+
+   # If a subnet_cidr variable is passed explicitly, we use that,  
+   # otherwise, use the first 1/4 of available space to create a new subnet:
+   cidr_block = var.subnet_cidr != null ? var.subnet_cidr : cidrsubnet(one(data.aws_vpc.pre-provisioned[*]).cidr_block, 2, 0)
+   
    map_public_ip_on_launch = true
+   
    availability_zone = var.availability_zone
+   
    tags = {
       Name = "${var.name_tag} Subnet"
       Project = var.project_tag
@@ -106,7 +111,6 @@ locals {
 
 
 resource "aws_internet_gateway" "gw" {
-   count = var.vpc_id != null ? 0 : 1
    vpc_id = local.vpc.id
    tags = {
       Name = "${var.name_tag} Internet Gateway"
@@ -115,7 +119,6 @@ resource "aws_internet_gateway" "gw" {
 }
 
 resource "aws_route_table" "default" {
-   count = var.vpc_id != null ? 0 : 1
    vpc_id = local.vpc.id
 
    route {
@@ -129,7 +132,6 @@ resource "aws_route_table" "default" {
 }
 
 resource "aws_route_table_association" "main" {
-  count = var.vpc_id != null ? 0 : 1
   subnet_id = one(aws_subnet.main[*].id)
   route_table_id = one(aws_route_table.default[*].id)
 }
@@ -368,7 +370,7 @@ resource "aws_instance" "head_node" {
   # associate_public_ip_address = true
   network_interface {
     device_index = 0    # MUST be 0
-    network_interface_id = var.use_efa == true ? aws_network_interface.efa_network_adapter.id : aws_network_interface.standard.id
+    network_interface_id = aws_network_interface.head_node.id
   }
 
   # This logic isn't perfect since some ena instance types can be in a placement group also
@@ -404,31 +406,18 @@ data "template_file" "init_instance" {
 }
 
 # Can only attach efa adaptor to a stopped instance!
-resource "aws_network_interface" "standard" {
+resource "aws_network_interface" "head_node" {
   
   subnet_id   = local.subnet.id
-  description = "The network adaptor to attach to the instance if EFA is not supported"
+  description = "The network adaptor to attach to the head_node instance"
   security_groups = [aws_security_group.base_sg.id,
                      aws_security_group.ssh_ingress.id,
                      aws_security_group.efs_sg.id]
-  tags = {
-      Name = "${var.name_tag} Standard Network Adapter"
-      Project = var.project_tag
-  }
-}
+  
+  interface_type = var.use_efa == true ? "efa" : null 
 
-# Can only attach efa adaptor to a stopped instance!
-resource "aws_network_interface" "efa_network_adapter" {
-  
-  subnet_id   = local.subnet.id
-  description = "The Elastic Fabric Adapter to attach to instance if supported"
-  security_groups = [aws_security_group.base_sg.id,
-                     aws_security_group.ssh_ingress.id,
-                     aws_security_group.efs_sg.id]
-  
-  interface_type = "efa"
   tags = {
-      Name = "${var.name_tag} EFA Network Adapter"
+      Name = "${var.name_tag} Head Node Network Adapter"
       Project = var.project_tag
   }
 }

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -80,8 +80,8 @@ resource "aws_subnet" "main" {
    vpc_id = local.vpc.id
 
    # If a subnet_cidr variable is passed explicitly, we use that,  
-   # otherwise, use the first 1/4 of available space to create a new subnet:
-   cidr_block = var.subnet_cidr != null ? var.subnet_cidr : cidrsubnet(one(data.aws_vpc.pre-provisioned[*]).cidr_block, 2, 0)
+   # otherwise, divide the VPC by four and use 1/4 for a new subnet 
+   cidr_block = var.subnet_cidr != null ? var.subnet_cidr : cidrsubnet(one(data.aws_vpc.pre-provisioned[*]).cidr_block, 2, var.subnet_quartile - 1)
    
    map_public_ip_on_launch = true
    

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -102,6 +102,12 @@ variable "subnet_cidr" {
 
 }
 
+variable "subnet_quartile" {
+  description = "If a specific subnet_cidr is not provided, the quartile of VPC address space to use for the created subnet.  Optional."
+  type = number
+  default = 1
+
+}
 
 variable "managed_policies" {
   description = "The attached IAM policies granting machine permissions"

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -79,13 +79,25 @@ variable "vpc_id" {
 
 
 variable "subnet_id" {
-  description = "The ID of an existing Subnect within the target VPC.  Must be specified if using an exsiting VPC."
+  description = "The ID of an existing Subnet within the target VPC to use.  If not provided a Subnet will be created."
   type = string
   default = null
 
   validation {
     condition     = var.subnet_id == null ? true : ( length(var.subnet_id) > 7 && substr(var.subnet_id, 0, 7) == "subnet-" )
     error_message = "The subnet_id value must start with \"subnet-\"."
+  }
+
+}
+
+variable "subnet_cidr" {
+  description = "An explicit CIDR block to use for the created Subnet, if subnet_id is not specified.  Optional."
+  type = string
+  default = null
+
+  validation {
+    condition     = var.subnet_cidr == null ? true : can(cidrhost(var.subnet_cidr, 0))
+    error_message = "The subnet_cidr variable must be a valid CIDR notation (e.g. \"10.0.0.0/24\")."
   }
 
 }


### PR DESCRIPTION
This simplifies main.tf, and also allows the option to auto-create a new subnet within an existing empty VPC. 

The `head_node_ip` variable is a WIP and isn't currently used.  
