### PR TITLE
Skips deployment of AWS networking-related resources for cases where existing subnet_id, vpc_id provided

### DIFF
--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -111,6 +111,7 @@ locals {
 
 
 resource "aws_internet_gateway" "gw" {
+   count = var.subnet_id != null ? 0 : 1
    vpc_id = local.vpc.id
    tags = {
       Name = "${var.name_tag} Internet Gateway"
@@ -119,6 +120,7 @@ resource "aws_internet_gateway" "gw" {
 }
 
 resource "aws_route_table" "default" {
+   count = var.subnet_id != null ? 0 : 1
    vpc_id = local.vpc.id
 
    route {
@@ -132,6 +134,7 @@ resource "aws_route_table" "default" {
 }
 
 resource "aws_route_table_association" "main" {
+  count = var.subnet_id != null ? 0 : 1
   subnet_id = one(aws_subnet.main[*].id)
   route_table_id = one(aws_route_table.default[*].id)
 }
@@ -287,6 +290,7 @@ data "aws_ami" "centos_stream_9" {
 
 # Work around to get a public IP assigned when using EFA
 resource "aws_eip" "head_node" {
+  count = var.subnet_id != null ? 0 : 1
   depends_on = [aws_internet_gateway.gw]
   vpc        = true
   instance   = aws_instance.head_node.id
@@ -333,6 +337,7 @@ resource "aws_instance" "head_node" {
 
   }
 
+  # depends_on = [var.subnet_id != null ? aws_internet_gateway.gw, aws_efs_file_system.main_efs, aws_efs_mount_target.mount_target_main_efs : aws_efs_file_system.main_efs, aws_efs_mount_target.mount_target_main_efs]
   depends_on = [aws_internet_gateway.gw,
                 aws_efs_file_system.main_efs,
                 aws_efs_mount_target.mount_target_main_efs]

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -337,7 +337,6 @@ resource "aws_instance" "head_node" {
 
   }
 
-  # depends_on = [var.subnet_id != null ? aws_internet_gateway.gw, aws_efs_file_system.main_efs, aws_efs_mount_target.mount_target_main_efs : aws_efs_file_system.main_efs, aws_efs_mount_target.mount_target_main_efs]
   depends_on = [aws_internet_gateway.gw,
                 aws_efs_file_system.main_efs,
                 aws_efs_mount_target.mount_target_main_efs]

--- a/terraform/outputs.tf
+++ b/terraform/outputs.tf
@@ -1,16 +1,16 @@
 output "instance_id" {
   description = "The EC2 instance id"
-  value       = aws_instance.head_node.id
+  value       = one(aws_instance.head_node[*]).id
 }
 
 output "instance_public_ip" {
   description = "Public IP Address of the EC2 Instance"
-  value       = aws_eip.head_node.public_ip
+  value       = one(aws_eip.head_node[*]) != null ? one(aws_eip.head_node[*]).public_ip : null
 }
 
 output "instance_public_dns" {
   description = "Public DNS Address of the EC2 Instance"
-  value       = aws_eip.head_node.public_dns
+  value       = one(aws_eip.head_node[*]) != null ? one(aws_eip.head_node[*]).public_dns : null
 }
 
 output "key_name" {
@@ -65,13 +65,8 @@ output "aws_placement_group" {
   value       = aws_placement_group.cloud_sandbox_placement_group.id
 }
 
-#output "login_command" {
-#  description = "SSH Login"
-#  value       = "ssh -i ~/.ssh/${var.key_name}.pem centos@${aws_eip.head_node.public_dns}"
-#}
-
 output "login_command" {
    description = "SSH Login"
-   value = "ssh -i ~/.ssh/${var.key_name}.pem ec2-user@${aws_eip.head_node.public_dns}"
+   value = one(aws_eip.head_node[*]) != null ? "ssh -i ~/.ssh/${var.key_name}.pem ec2-user@${one(aws_eip.head_node[*]).public_dns}" : "ssh -i ~/.ssh/${var.key_name}.pem ec2-user@${aws_instance.head_node.private_dns}"
 }
 


### PR DESCRIPTION
This PR updates the working branch x86_64 with some minor networking changes to deploy into an existing VPC/Subnet with external networking components (as is present in the NOAA AWS environment).

This change assumes that if both a vpc_id and subnet_id are provided to the template as variables, then the networking components are already in place outside of Terraform to enable communication. In this situation, the head node will not automatically be assigned an EIP, an Internet Gateway is not created, and a Route Table and Route Table Association are skipped as well.  