### PR TITLE
Fixed the bug

### DIFF
--- a/terraform/security.tf
+++ b/terraform/security.tf
@@ -1,17 +1,17 @@
-# base sg
+# Base SG - Allows all traffic within the same security group
 resource "aws_security_group" "base_sg" {
   vpc_id = local.vpc.id
   ingress {
-    self      = true
-    from_port = 0
-    to_port   = 0
-    protocol  = -1
+    from_port   = 0
+    to_port     = 0
+    protocol    = -1
+    self        = true
   }
   egress {
-    self      = true
-    from_port = 0
-    to_port   = 0
-    protocol  = -1
+    from_port   = 0
+    to_port     = 0
+    protocol    = -1
+    cidr_blocks = ["0.0.0.0/0"]
   }
   tags = {
     Name    = "${var.name_tag} Base SG"
@@ -19,28 +19,28 @@ resource "aws_security_group" "base_sg" {
   }
 }
 
+# EFS SG - Allows NFS traffic only from base_sg
 resource "aws_security_group" "efs_sg" {
-   vpc_id = local.vpc.id
-   ingress {
-     self = true
-     from_port = 2049
-     to_port = 2049
-     protocol = "tcp"
-   }
-   # allow all outgoing from NFS
-   egress {
-      from_port = 0
-      to_port = 0
-      protocol = -1
-      cidr_blocks = ["0.0.0.0/0"]
-   }
-   
-   tags = {
-      Name = "${var.name_tag} EFS SG"
-      Project = var.project_tag
-   }
+  vpc_id = local.vpc.id
+  ingress {
+    from_port       = 2049
+    to_port         = 2049
+    protocol        = "tcp"
+    security_groups = [aws_security_group.base_sg.id]
+  }
+  egress {
+    from_port   = 0
+    to_port     = 0
+    protocol    = -1
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+  tags = {
+    Name    = "${var.name_tag} EFS SG"
+    Project = var.project_tag
+  }
 }
 
+# SSH SG - Allows SSH only from approved IPs
 resource "aws_security_group" "ssh_ingress" {
   vpc_id = local.vpc.id
   ingress {
@@ -50,8 +50,15 @@ resource "aws_security_group" "ssh_ingress" {
     protocol    = "tcp"
     cidr_blocks = var.allowed_ssh_cidr_list
   }
+  egress {
+    from_port   = 0
+    to_port     = 0
+    protocol    = -1
+    cidr_blocks = ["0.0.0.0/0"]
+  }
   tags = {
-      Name = "${var.name_tag} SSH SG"
-      Project = var.project_tag
-   }
+    Name    = "${var.name_tag} SSH SG"
+    Project = var.project_tag
+  }
 }
+


### PR DESCRIPTION

Removed Duplicate Rules:

Cleaned up repeated ingress and egress blocks in base_sg and efs_sg.

Fixed EFS Security Group:

Allowed only NFS traffic (2049/tcp) from base_sg using security_groups.

Cleaned Up Tags:

Removed duplicate tags blocks and kept one per security group.

Corrected Egress Rules:

Ensured egress allows all traffic to 0.0.0.0/0.

Refined SSH SG:

Restricted SSH ingress (22/tcp) to only the approved CIDR list