### PR TITLE
 Adding a basic CloudWatch logging framework for Cloud-Sandbox

### DIFF
--- a/cloudflow/tests/verify_cloudwatch.py
+++ b/cloudflow/tests/verify_cloudwatch.py
@@ -1,0 +1,50 @@
+"""Simple script to verify CloudWatch logging functionality."""
+
+import os
+import time
+from cloudflow.utils.cloudwatch_handler import CloudWatchHandler
+from haikunator import Haikunator
+
+def main():
+    """Test CloudWatch logging functionality."""
+    # Generate a unique run name
+    haikunator = Haikunator()
+    run_name = haikunator.haikunate()
+    
+    # Initialize handler
+    handler = CloudWatchHandler(
+        user_id=os.getenv('USER', 'test-user'),
+        job_id='test-job',
+        haiku_name=run_name
+    )
+    
+    try:
+        # Test different log levels
+        print(f"Testing CloudWatch logging with run name: {run_name}")
+        
+        # Basic info log
+        handler.info("Starting test run", {"test": "basic info"})
+        
+        # Warning with extra data
+        handler.warning("Resource usage high", {"cpu": 85, "memory": "70%"})
+        
+        # Error with stack trace
+        try:
+            raise ValueError("Test error")
+        except Exception as e:
+            handler.error("Caught exception", {"error": str(e), "type": type(e).__name__})
+        
+        # Debug message
+        handler.debug("Detailed debug info", {"step": "complete"})
+        
+        print("\nLogs sent successfully!")
+        print(f"Check CloudWatch console for logs in group: /cloud-sandbox/users/{os.getenv('USER', 'test-user')}/jobs/test-job-{run_name}")
+        print("Note: It may take a few minutes for logs to appear in CloudWatch")
+        
+    finally:
+        # Clean up
+        handler.cleanup()
+        print("\nCleanup completed")
+
+if __name__ == "__main__":
+    main() 

--- a/cloudflow/utils/cloudwatch_handler.py
+++ b/cloudflow/utils/cloudwatch_handler.py
@@ -1,0 +1,137 @@
+import logging
+import boto3
+import json
+from datetime import datetime
+from typing import Optional, Dict, Any
+from watchtower import CloudWatchLogHandler
+
+class CloudWatchHandler:
+    """CloudWatch logging handler for Cloud-Sandbox."""
+    
+    def __init__(self, user_id: str, job_id: str, haiku_name: str):
+        """
+        Initializes the CloudWatch handler.
+
+        Parameters
+        ----------
+        user_id : str
+            User identifier.
+
+        job_id : str
+            Job identifier.
+
+        haiku_name : str
+            Unique run name.
+        """
+        self.user_id = user_id
+        self.job_id = job_id
+        self.haiku_name = haiku_name
+        
+        # Sets up log group and stream names
+        self.log_group = f"/cloud-sandbox/users/{user_id}/jobs/{job_id}-{haiku_name}"
+        self.stream_name = f"{job_id}-{haiku_name}"
+        
+        # Initializes the AWS client
+        self.client = boto3.client('logs')
+        
+        # Creat log group if it doesn't exist
+        self._ensure_log_group()
+        
+        # Set up the handler
+        self.handler = CloudWatchLogHandler(
+            log_group_name=self.log_group,
+            log_stream_name=self.stream_name,
+            boto3_client=self.client
+        )
+        
+        # Configures logger
+        self.logger = logging.getLogger(f"cloudwatch.{user_id}.{job_id}")
+        self.logger.setLevel(logging.INFO)
+        self.logger.addHandler(self.handler)
+        
+        # Log initialization
+        self.info("CloudWatch logging initialized", {
+            "user_id": user_id,
+            "job_id": job_id,
+            "haiku_name": haiku_name
+        })
+    
+    def _ensure_log_group(self) -> None:
+        """Ensure the log group exists, create it if it doesn't."""
+        try:
+            self.client.create_log_group(logGroupName=self.log_group)
+            # Setting retention policy to be 30 days by default
+            self.client.put_retention_policy(
+                logGroupName=self.log_group,
+                retentionInDays=30
+            )
+        except self.client.exceptions.ResourceAlreadyExistsException:
+            # Log group already exists(this should be fine)
+            pass
+        except Exception as e:
+            # Logs the error but doesnt raise it. So that we can continue even if log group creation fails
+            print(f"Error creating log group: {str(e)}")
+    
+    def _format_message(self, message: str, extra: Optional[Dict[str, Any]] = None) -> str:
+        """
+        Formats the log message with metadata.
+
+        Parameters
+        ----------
+        message : str
+            The log message.
+
+        extra : dict, optional
+            Additional metadata to include.
+
+        Returns
+        -------
+        str
+            JSON string containing formatted log message.
+        """
+        log_data = {
+            "timestamp": datetime.utcnow().isoformat(),
+            "message": message,
+            "user_id": self.user_id,
+            "job_id": self.job_id,
+            "haiku_name": self.haiku_name
+        }
+        
+        if extra:
+            log_data.update(extra)
+            
+        return json.dumps(log_data)
+    
+    def info(self, message: str, extra: Optional[Dict[str, Any]] = None) -> None:
+        """Logs an info message.
+    
+        Parameters
+        ----------
+        message : str
+            The log message.
+
+        extra : dict, optional
+            Additional metadata to include.
+        """
+        self.logger.info(self._format_message(message, extra))
+    
+    def warning(self, message: str, extra: Optional[Dict[str, Any]] = None) -> None:
+        """Logs a warning message."""
+        self.logger.warning(self._format_message(message, extra))
+    
+    def error(self, message: str, extra: Optional[Dict[str, Any]] = None) -> None:
+        """Logs an error message."""
+        self.logger.error(self._format_message(message, extra))
+    
+    def debug(self, message: str, extra: Optional[Dict[str, Any]] = None) -> None:
+        """Logs a debug message."""
+        self.logger.debug(self._format_message(message, extra))
+    
+    def cleanup(self) -> None:
+        """Cleans up the resources used by the handler."""
+        try:
+            self.logger.removeHandler(self.handler)
+            self.handler.close()
+            self.info("CloudWatch logging cleanup completed")
+        except Exception as e:
+            print(f"Error during cleanup: {str(e)}") 


### PR DESCRIPTION
This is a draft PR submitted as part of my preliminary contribution for the GSoC project [Increased logging for Cloudflow.](https://github.com/ioos/gsoc/issues/86) It implements the foundational work for AWS CloudWatch logging in Cloud-Sandbox mentioned in [Issue #98](https://github.com/ioos/Cloud-Sandbox/issues/98) with the relevant improvements in [Issue #96](https://github.com/ioos/Cloud-Sandbox/issues/96) which which introduces the use of a haikunator generated run name for asset tagging to dynamically create log groups and streams.

**Here is a summary of the changes:**
**1. CloudWatchHandler Class**
- Location: cloudflow/utils/cloudwatch_handler.py
- Dynamically creates log groups and streams using user_id, job_id and a haikunator generated run name
- Provides a structured JSON formatted logging with support for info, warning, error and debug levels.
- Included a cleanup method for a safe resource release.

**2. Integration into the Workflow**
- Updated simple_fcst_flow in cloudflow/workflows/flows.py
- The logging now includes key events such as cluster initialization, job setup, forecast  execution, and cluster termination
- Uses setup_cloudwatch_logging() to initialize structured logging early in the flow.

**3. Haikunator Integration (from Issue #96)**
- Follows the updated design where the random haikunator generated names are appended to job related assets for improved traceability.
- These names are also used to construct CloudWatch log group and stream names

**4. Test Script for CloudWatch Logging**
Location: cloudflow/tests/verify_cloudwatch.py
Tests for:
Log group creation
Delivery of structured log messages (JSON)
Support for multiple log levels
Metadata inclusion in logs

### Here are the testing Instructions to run verify_cloudwatch.py

**Prerequisites**
- Have your AWS credentials configured with CloudWatch permissions.
- Have a python environment with the following required packages: pip install boto3 watchtower haikunator

**Steps to Run**
Run the verification script from the cloudflow directory:
  python tests/verify_cloudwatch.py
  
<img width="822" alt="Screenshot 2025-04-08 at 2 25 18 AM" src="https://github.com/user-attachments/assets/657b89ff-3fbd-40fb-9dd7-7fbe556ace39" />

After this, in the AWS CloudWatch Console navigate to Logs -> Log groups and verify that a log group in the format (/cloud-sandbox/users/{your_user_id}/jobs/test-job-{haikunator_run_name}) is created, and that log entries appear with the expected JSON structure as shown in the screenshot.

<img width="1470" alt="Screenshot 2025-04-08 at 2 27 16 AM" src="https://github.com/user-attachments/assets/0787e398-2b7c-4d93-961e-9b1130c28010" />

**Expected Results:**
 • Log entries should include a timestamp, log level, message, user ID, job ID, haikunator generated run name, and additional context as shown in the screenshot below.
 • Logs should be delivered to AWS CloudWatch within a few minutes.
 
<img width="1446" alt="Screenshot 2025-04-08 at 2 28 11 AM" src="https://github.com/user-attachments/assets/d7121fc5-4829-4437-8cdb-1cdc652fbf9c" />

**Future enhancements will include:**
- Extending the CloudWatch integration to additional workflows like fcst_flow, multi_hindcast_flow,etc. 
- Adding some custom metrics like resource usage, and job duration
- Enhancing structured error logging and exception tracking.
- Implementing filtering tools for job and user level log querying.
- Adding comprehensive testing, validation, and documentation.



